### PR TITLE
Update the runner used for the trigger pipeline job

### DIFF
--- a/.github/workflows/mirror_and_trigger_ci.yml
+++ b/.github/workflows/mirror_and_trigger_ci.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   mirror_and_trigger:
-    runs-on: self-hosted
+    runs-on: gitlab
     environment: GITLAB
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Update the runner used for the trigger pipeline job. Since the new GPU runners also share the `self-hosted` label, we need to update the runner to a `gitlab` one in order to trigger the internal pipeline, as the external GPU runners cannot resolve the internal hostname.